### PR TITLE
Update Heroic to 2.9.2

### DIFF
--- a/abi_used_symbols
+++ b/abi_used_symbols
@@ -346,7 +346,6 @@ libc.so.6:clock
 libc.so.6:clock_getres
 libc.so.6:clock_gettime
 libc.so.6:clone
-libc.so.6:close
 libc.so.6:closedir
 libc.so.6:closelog
 libc.so.6:creat64
@@ -355,10 +354,6 @@ libc.so.6:dirfd
 libc.so.6:dirname
 libc.so.6:div
 libc.so.6:dl_iterate_phdr
-libc.so.6:dlclose
-libc.so.6:dlerror
-libc.so.6:dlopen
-libc.so.6:dlsym
 libc.so.6:dup
 libc.so.6:dup2
 libc.so.6:dup3
@@ -402,7 +397,6 @@ libc.so.6:freopen64
 libc.so.6:fseek
 libc.so.6:fseeko
 libc.so.6:fseeko64
-libc.so.6:fstat64
 libc.so.6:fstatfs64
 libc.so.6:ftell
 libc.so.6:ftello
@@ -498,7 +492,6 @@ libc.so.6:munmap
 libc.so.6:nanosleep
 libc.so.6:newlocale
 libc.so.6:nl_langinfo
-libc.so.6:open64
 libc.so.6:open_memstream
 libc.so.6:openat64
 libc.so.6:opendir
@@ -520,15 +513,9 @@ libc.so.6:prctl
 libc.so.6:printf
 libc.so.6:program_invocation_short_name
 libc.so.6:pthread_attr_destroy
-libc.so.6:pthread_attr_getstack
 libc.so.6:pthread_attr_init
 libc.so.6:pthread_attr_setdetachstate
-libc.so.6:pthread_getattr_np
-libc.so.6:pthread_getspecific
-libc.so.6:pthread_key_create
-libc.so.6:pthread_key_delete
 libc.so.6:pthread_self
-libc.so.6:pthread_setspecific
 libc.so.6:ptrace
 libc.so.6:putchar
 libc.so.6:puts
@@ -576,7 +563,6 @@ libc.so.6:shmctl
 libc.so.6:shmdt
 libc.so.6:shmget
 libc.so.6:shutdown
-libc.so.6:sigaction
 libc.so.6:sigaddset
 libc.so.6:sigaltstack
 libc.so.6:sigdelset
@@ -592,7 +578,6 @@ libc.so.6:socket
 libc.so.6:socketpair
 libc.so.6:sprintf
 libc.so.6:srand
-libc.so.6:stat64
 libc.so.6:statfs64
 libc.so.6:statvfs64
 libc.so.6:stderr
@@ -680,7 +665,6 @@ libc.so.6:wmemchr
 libc.so.6:wmemcmp
 libc.so.6:wmemcpy
 libc.so.6:wmemmove
-libc.so.6:write
 libc.so.6:writev
 libcairo.so.2:cairo_create
 libcairo.so.2:cairo_destroy
@@ -813,6 +797,7 @@ libdbus-1.so.3:dbus_watch_set_data
 libdl.so.2:dladdr
 libdl.so.2:dlclose
 libdl.so.2:dlerror
+libdl.so.2:dlinfo
 libdl.so.2:dlopen
 libdl.so.2:dlsym
 libdrm.so.2:drmFreeDevices
@@ -1352,6 +1337,7 @@ libsmime3.so:SEC_PKCS12DecoderValidateBags
 libsmime3.so:SEC_PKCS12DecoderVerify
 libsmime3.so:SEC_PKCS12EnableCipher
 libsmime3.so:SEC_PKCS12SetPreferredCipher
+libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE10_M_disposeEv
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE6resizeEmc
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE7reserveEm
 libstdc++.so.6:_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE9_M_createERmm

--- a/package.yml
+++ b/package.yml
@@ -1,8 +1,8 @@
 name       : heroic-games-launcher
-version    : 2.9.1
-release    : 19
+version    : 2.9.2
+release    : 20
 source     :
-    - https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/archive/refs/tags/v2.9.1.tar.gz : 98b3e8d835a5c53915553e5cc32ec3bbe9b02d5755b28080b904f8b5b532c879
+    - https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/archive/refs/tags/v2.9.2.tar.gz : c1e35592801d6e5d96dac5275acdf3e604eb3f3f9f657d66b3cbea9a708fbb9d
 homepage   : https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher
 license    : GPL-3.0-or-later
 component  : games

--- a/pspec_x86_64.xml
+++ b/pspec_x86_64.xml
@@ -3,8 +3,8 @@
         <Name>heroic-games-launcher</Name>
         <Homepage>https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher</Homepage>
         <Packager>
-            <Name>Zach Bacon</Name>
-            <Email>zachbacon@vba-m.com</Email>
+            <Name>Marcus Mellor</Name>
+            <Email>infinitymdm@gmail.com</Email>
         </Packager>
         <License>GPL-3.0-or-later</License>
         <PartOf>games</PartOf>
@@ -137,12 +137,12 @@
         </Files>
     </Package>
     <History>
-        <Update release="19">
-            <Date>2023-07-27</Date>
-            <Version>2.9.1</Version>
+        <Update release="20">
+            <Date>2023-09-15</Date>
+            <Version>2.9.2</Version>
             <Comment>Packaging update</Comment>
-            <Name>Zach Bacon</Name>
-            <Email>zachbacon@vba-m.com</Email>
+            <Name>Marcus Mellor</Name>
+            <Email>infinitymdm@gmail.com</Email>
         </Update>
     </History>
 </PISI>


### PR DESCRIPTION
### Summary

Update Heroic Games Launcher to version 2.9.2.

Notable Fixes & Features:
- Fixed three-dot menu closing when hovering certain items
- Fixed installation of EOS Overlay
- Fixed alignment of current download component when sidebar is collapsed
- Fixed issues with missing games metadata for GOG
- Fixed some issues for Amazon Games
- Fixed issue with egl-sync
- Fixed remembering if window is maximized
- Fixed installing all DLCs not adding them to the queue
- Make sure the game is available before auto-updating
- Await for GOG uninstaller to finish before updating the state
- Added a new System Information Tab to the Heroic Settings
- Added support for installing and enabling DXVK-NVAPI
- Added user feedback when copying log to clipboard
- Added ExperimentalFeatures feature setting support

### Test Plan

Launch Heroic and make sure things generally look ok. Check the store pages, library, etc. Run a game and make sure things launch correctly.

### Checklist

- [x] Package was built and tested against unstable
